### PR TITLE
Fix Makefile

### DIFF
--- a/02/Makefile
+++ b/02/Makefile
@@ -1,6 +1,6 @@
 fib.bin: fib.c
 	riscv64-unknown-elf-gcc -S fib.c
-	riscv64-unknown-elf-gcc -Wl,-Ttext=0x0 -nostdlib -o fib fib.s
+	riscv64-unknown-elf-gcc -Wl,-Ttext=0x0 -nostdlib -march=rv64i -mabi=lp64 -o fib fib.s
 	riscv64-unknown-elf-objcopy -O binary fib fib.bin
 
 clean:


### PR DESCRIPTION
This fix disables 'instruction compression' since the emulator can not handle such instructions at this stage of implementation.